### PR TITLE
Fixed main page image resizing.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
 
     <link href="http://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{site.url}}/css/style.css">
+    <link rel="stylesheet" href="css/style.css">
 </head>
 
 <body>

--- a/css/style.css
+++ b/css/style.css
@@ -46,15 +46,33 @@ code {
 .main .title hr {
     margin: 2em 4em 1.5em;
 }
-.main .title {
-    background: url(../img/cleve_ns.jpg) no-repeat center center fixed;
-    -webkit-background-size: cover;
-    -moz-background-size: cover;
-    -o-background-size: cover;
-    background-size: cover;
-    background-position-y: 0;
-    margin-bottom: 50px;
+
+@media (max-width: 749px) {
+    .main .title {
+        background-image: url(../img/cleve_ns.jpg);
+        background-repeat: no-repeat;
+        background-position: center center;
+        -webkit-background-size: cover;
+        -moz-background-size: cover;
+        -o-background-size: cover;
+        background-size: cover;
+        margin-bottom: 50px;
+    }
 }
+
+
+@media (min-width: 750px) {
+    .main .title {
+        background-image: url(../img/cleve_ns.jpg);
+        background-repeat: no-repeat;
+        background-position: center center;
+        background-attachment: fixed;
+        background-position-y: 0;
+        background-size: contain;
+        margin-bottom: 50px;
+    }
+}
+
 
 .main .title h1 {
     color: #FFF;


### PR DESCRIPTION
Fixes #17.

I used the media query technique discussed in the issue.  When the screen is small, we use `background-size: cover;` in order to see the picture.  This, however, does not have the cool fixed scrolling effect.  When the screen is large, `background-attachment: fixed;`  is enabled.

I also changed the `<link>` element in head.html from an absolute path to a relative one.  The absolute path was preventing me from running the site locally on my machine and seeing the CSS changes I was making.
